### PR TITLE
attach a link on button 'See More'

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,22 +137,11 @@
 													<li>Mathematical Review, American Mathematical Society (AMS)</li>
 													<li>US National Science Foundation</li>
 												</ul>
-
 												<h3>Committee Members</a></h3>
 
 												<ul>
-												  <li>Placeholder Name</li>
-												  <li>John Doe</li>
-												  <li>Jane Smith</li>
-												</ul>
-												<ul class="actions">
-													<li>
-														<a href="https://poems2024.inria.fr/" class="button" target="_blank" rel="noopener noreferrer">See More</a>
-													</li>
-													<li> POEMs (POlytopal Element Methods in Mathematics and Engineering) </li>
-													
-												</ul>
-												
+													<li> <a href="https://poems2024.inria.fr/" target="_blank" rel="noopener noreferrer">POEMs (POlytopal Element Methods in Mathematics and Engineering) </a></li>
+												</ul>												
 																			
 											</div>
 										</article>

--- a/index.html
+++ b/index.html
@@ -138,12 +138,20 @@
 													<li>US National Science Foundation</li>
 												</ul>
 
-												<h3>Committee Members</h3>
+												<h3>Committee Members</a></h3>
+
 												<ul>
-													<li>Placeholder Name</li>
-													<li>John Doe</li>
-													<li>Jane Smith</li>
+												  <li>Placeholder Name</li>
+												  <li>John Doe</li>
+												  <li>Jane Smith</li>
 												</ul>
+												<ul class="actions">
+													<li>
+														<a href="https://poems2024.inria.fr/" class="button" target="_blank" rel="noopener noreferrer">See More</a>
+													</li>
+												</ul>
+												
+																			
 											</div>
 										</article>
 										


### PR DESCRIPTION
The 'Committee Members' section was not displayed as an underlined hyperlink on the website, so I added a new button to make it more convenient to access.